### PR TITLE
File paths for system commands are now quoted to allow for paths with spaces.

### DIFF
--- a/bin/ipa_utilities
+++ b/bin/ipa_utilities
@@ -64,7 +64,7 @@ command :convert do |c|
     begin
 
       puts "\nConverting P12 to Pem"
-      system "openssl pkcs12 -in #{path} -out #{output_path} -nodes -clcerts"
+      system "openssl pkcs12 -in '#{path}' -out '#{output_path}' -nodes -clcerts"
       output("Pem saved at ", output_path)
 
     ensure

--- a/lib/ipa_utilities/Parsers.rb
+++ b/lib/ipa_utilities/Parsers.rb
@@ -51,6 +51,8 @@ end
 
 class ProvisionProfile
 
+  attr_reader :provision_path
+
   def initialize(provision_path)
     @provision_path = provision_path
     @data = CFPropertyList.native_types(read_profile)
@@ -138,7 +140,7 @@ class ProvisionProfile
   private
 
   def read_profile
-    cmd = "security cms -D -i #{@provision_path} > tmp.plist"
+    cmd = "security cms -D -i '#{@provision_path}' > tmp.plist"
     say cmd if $verbose
     system(cmd)
 

--- a/lib/ipa_utilities/code_signer.rb
+++ b/lib/ipa_utilities/code_signer.rb
@@ -11,7 +11,7 @@ class CodeSigner
   end
 
   def self.signature_valid?(ipa)
-    system("codesign -v #{ipa.app_path} 2>&1")
+    system("codesign -v '#{ipa.app_path}' 2>&1")
     $?.exitstatus == 0
   end
 
@@ -48,7 +48,7 @@ class CodeSigner
   end
 
   def delete_old_signature
-    system "rm -rf #{@app_path}/_CodeSignature"
+    system "rm -rf '#{@app_path}/_CodeSignature'"
     puts "Deleting old code sign file" if $verbose
   end
 

--- a/lib/ipa_utilities/ipa_parser.rb
+++ b/lib/ipa_utilities/ipa_parser.rb
@@ -28,12 +28,12 @@ class IpaParser
   def zip(path)
     say "Zipping " + @ipa_path.green if $verbose
     system "zip -qr \"_new.ipa\" Payload"
-    system "cp _new.ipa #{path}"
+    system "cp _new.ipa '#{path}'"
     say "Resigned ipa saved at " + path.green
   end
 
   def cleanup
-    system "rm -rf #{zip_out_path}"
+    system "rm -rf '#{zip_out_path}'"
     say "Deleting directory #{zip_out_path}" if $verbose
   end
 
@@ -51,7 +51,7 @@ class IpaParser
 
   def unzip
     say "Unzipping '#{@ipa_path.green}' to '#{zip_out_path}'"  if $verbose
-    system "unzip #{@ipa_path} -d #{zip_out_path} | logger -t ipa_utilities"
+    system "unzip '#{@ipa_path}' -d '#{zip_out_path}' | logger -t ipa_utilities"
 
     change_directory
   end


### PR DESCRIPTION
I noticed a bug whereby paths with spaces would cause a failure. So I've quoted all paths used in `system` calls.

I've also exposed `provision_path` in `ProvisioningProfile` via `attr_reader :provision_path`.